### PR TITLE
remove -std=c++11 from PKG_CPPFLAGS

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -9,7 +9,7 @@ OBJECTS_C = $(SOURCES_C:.c=.o)
 
 OBJECTS = $(SOURCES:.cpp=.o) $(OBJECTS_C)
  
-PKG_CPPFLAGS+= -std=c++11 -Wall -pedantic -pthread -fPIC -O2 -g -I../inst -I../inst/libvol2bird -I../inst/librave -I../inst/libhlhdf 
+PKG_CPPFLAGS+= -Wall -pedantic -pthread -fPIC -O2 -g -I../inst -I../inst/libvol2bird -I../inst/librave -I../inst/libhlhdf 
 PKG_CFLAGS+= -Wall -pedantic -pthread -fPIC -O2 -g -I../inst -I../inst/libvol2bird -I../inst/librave  -I../inst/libhlhdf  -I../inst/libtnc 
 PKG_CFLAGS+= `$(R_HOME)/bin/Rscript -e "RcppGSL:::CFlags()"`
 #-I/usr/include/hdf5/serial -I/usr/lib/x86_64-linux-gnu/hdf5/serial

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,4 @@
-
-$(info The name of the shared library to be created is: $(SHLIB))               
+$(info The name of the shared library to be created is: $(SHLIB))
 
 SOURCES = $(wildcard ./*.cpp )
 
@@ -8,26 +7,28 @@ SOURCES_C = $(wildcard ./libvol2bird/*.c ./librave/*.c ./libhlhdf/*.c ./libtnc/*
 OBJECTS_C = $(SOURCES_C:.c=.o)
 
 OBJECTS = $(SOURCES:.cpp=.o) $(OBJECTS_C)
- 
-PKG_CPPFLAGS+= -Wall -pedantic -pthread -fPIC -O2 -g -I../inst -I../inst/libvol2bird -I../inst/librave -I../inst/libhlhdf 
-PKG_CFLAGS+= -Wall -pedantic -pthread -fPIC -O2 -g -I../inst -I../inst/libvol2bird -I../inst/librave  -I../inst/libhlhdf  -I../inst/libtnc 
+
+PKG_CPPFLAGS+= -Wall -pedantic -pthread -fPIC -O2 -g -I../inst -I../inst/libvol2bird -I../inst/librave -I../inst/libhlhdf
+PKG_CFLAGS+= -Wall -pedantic -pthread -fPIC -O2 -g -I../inst -I../inst/libvol2bird -I../inst/librave  -I../inst/libhlhdf  -I../inst/libtnc
 PKG_CFLAGS+= `$(R_HOME)/bin/Rscript -e "RcppGSL:::CFlags()"`
 #-I/usr/include/hdf5/serial -I/usr/lib/x86_64-linux-gnu/hdf5/serial
 
 # rave_bufr_io rave_simplexml omitted
 PKG_LIBS = `$(R_HOME)/bin/Rscript -e "RcppGSL:::LdFlags()"`
 
-
 RHDF5_LIBS = $(shell "$(R_HOME)/bin/Rscript" --vanilla --slave -e 'Rhdf5lib::pkgconfig("PKG_CXX_LIBS")')
 PKG_LIBS += $(RHDF5_LIBS)
+
+# system specfic settings for Adriaan's Mac:
+PKG_CPPFLAGS += -I/opt/local/include -I/opt/local/lib/proj49/include
+PKG_CFLAGS += -I/opt/local/include
+PKG_LIBS += -L/opt/local/lib/proj49/lib
 
 # uncomment below to print the contents of $(PKG_LIBS)
 $(info $$PKG_LIBS is [${PKG_LIBS}])
 
 PKG_LIBS += -lconfuse -lproj
 
-all: $(SHLIB) 
+all: $(SHLIB)
 
 # $(SHLIB): $(OBJECTS)
-
-	


### PR DESCRIPTION
* removes `PKG_CPPFLAGS+= -std=c++11` for compiler compatibility with clang
* some paths for Adriaan's mac